### PR TITLE
eslint: change isNaN to Number.isNaN

### DIFF
--- a/templates/js/es2015/www.ejs
+++ b/templates/js/es2015/www.ejs
@@ -36,7 +36,7 @@ server.on('listening', onListening);
 function normalizePort(val) {
   const port = parseInt(val, 10);
 
-  if (isNaN(port)) {
+  if (Number.isNaN(port)) {
     // named pipe
     return val;
   }


### PR DESCRIPTION
The global isNaN coerces non-numbers to numbers, returning true for anything that coerces to NaN. If this behavior is desired, make it explicit.
more details at https://github.com/airbnb/javascript#standard-library--isnan

I am sending a pull request to you because this would be nice to be included on the PR adding es2015 https://github.com/expressjs/generator/pull/176